### PR TITLE
Initialise `status` variable with `MS8607_status_ok`

### DIFF
--- a/src/SparkFun_PHT_MS8607_Arduino_Library.cpp
+++ b/src/SparkFun_PHT_MS8607_Arduino_Library.cpp
@@ -58,7 +58,7 @@ bool MS8607::isConnected(void)
 */
 enum MS8607_status MS8607::reset(void)
 {
-  enum MS8607_status status;
+  enum MS8607_status status = MS8607_status_ok;
 
   status = hsensor_reset();
   if (status != MS8607_status_ok)
@@ -250,7 +250,7 @@ bool MS8607::hsensor_is_connected(void)
 */
 enum MS8607_status MS8607::hsensor_reset(void)
 {
-  enum MS8607_status status;
+  enum MS8607_status status = MS8607_status_ok;
 
   _i2cPort->beginTransmission((uint8_t)MS8607_HSENSOR_ADDR);
   _i2cPort->write((uint8_t)HSENSOR_RESET_COMMAND);
@@ -312,7 +312,7 @@ enum MS8607_status MS8607::hsensor_crc_check(uint16_t value, uint8_t crc)
 */
 enum MS8607_status MS8607::hsensor_read_user_register(uint8_t *value)
 {
-  enum MS8607_status status;
+  enum MS8607_status status = MS8607_status_ok;
   uint8_t i2c_status;
   uint8_t buffer[1];
   buffer[0] = 0;
@@ -689,7 +689,7 @@ void MS8607::set_pressure_resolution(enum MS8607_pressure_resolution res)
 enum MS8607_status MS8607::psensor_read_eeprom_coeff(uint8_t command,
                                                      uint16_t *coeff)
 {
-  enum MS8607_status status;
+  enum MS8607_status status = MS8607_status_ok;
   uint8_t i2c_status;
   uint8_t buffer[2];
   uint8_t i;
@@ -763,7 +763,7 @@ enum MS8607_status MS8607::psensor_read_eeprom(void)
 enum MS8607_status MS8607::psensor_conversion_and_read_adc(uint8_t cmd,
                                                            uint32_t *adc)
 {
-  enum MS8607_status status;
+  enum MS8607_status status = MS8607_status_ok;
   uint8_t i2c_status;
   uint8_t buffer[3];
   uint8_t i;


### PR DESCRIPTION
A number of `status` variables are not initialised and the ESP32 compiler throws an error. 

The error is shown below.
```
C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp:792:3: error: 'status' is used uninitialized in this function [-Werror=uninitialized]

   if (status != MS8607_status_ok)

   ^
```

To fix the problem, I suggest initialising(set to default) all those `status` variables as `MS8607_status_ok`. They will be changed in the function if the status changes. It works OK on my ESP32 + U-blox MAX M8Q setup.

The full error compile log is below.
<details>
  <summary>Click to expand</summary>

```
Arduino: 1.8.13 (Windows Store 1.8.42.0) (Windows 10), Board: "Adafruit ESP32 Feather, 80MHz, 921600, None, Default"


C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\arduino-builder -dump-prefs -logger=machine -hardware C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\hardware -hardware C:\Users\Medad\Documents\ArduinoData\packages -tools C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\tools-builder -tools C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\hardware\tools\avr -tools C:\Users\Medad\Documents\ArduinoData\packages -built-in-libraries C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\libraries -libraries C:\Users\Medad\Documents\Arduino\libraries -fqbn=esp32:esp32:featheresp32:FlashFreq=80,UploadSpeed=921600,DebugLevel=none,PartitionScheme=default -vid-pid=10C4_EA60 -ide-version=10813 -build-path C:\Users\Medad\AppData\Local\Temp\arduino_build_974273 -warnings=all -build-cache C:\Users\Medad\AppData\Local\Temp\arduino_cache_329333 -prefs=build.warn_data_percentage=75 -prefs=runtime.tools.esptool_py.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\esptool_py\2.6.1 -prefs=runtime.tools.esptool_py-2.6.1.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\esptool_py\2.6.1 -prefs=runtime.tools.mkspiffs.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\mkspiffs\0.2.3 -prefs=runtime.tools.mkspiffs-0.2.3.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\mkspiffs\0.2.3 -prefs=runtime.tools.xtensa-esp32-elf-gcc.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\xtensa-esp32-elf-gcc\1.22.0-80-g6c4433a-5.2.0 -prefs=runtime.tools.xtensa-esp32-elf-gcc-1.22.0-80-g6c4433a-5.2.0.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\xtensa-esp32-elf-gcc\1.22.0-80-g6c4433a-5.2.0 -verbose C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\examples\Example2_VariousUnits\Example2_VariousUnits.ino

C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\arduino-builder -compile -logger=machine -hardware C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\hardware -hardware C:\Users\Medad\Documents\ArduinoData\packages -tools C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\tools-builder -tools C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\hardware\tools\avr -tools C:\Users\Medad\Documents\ArduinoData\packages -built-in-libraries C:\Program Files\WindowsApps\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\libraries -libraries C:\Users\Medad\Documents\Arduino\libraries -fqbn=esp32:esp32:featheresp32:FlashFreq=80,UploadSpeed=921600,DebugLevel=none,PartitionScheme=default -vid-pid=10C4_EA60 -ide-version=10813 -build-path C:\Users\Medad\AppData\Local\Temp\arduino_build_974273 -warnings=all -build-cache C:\Users\Medad\AppData\Local\Temp\arduino_cache_329333 -prefs=build.warn_data_percentage=75 -prefs=runtime.tools.esptool_py.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\esptool_py\2.6.1 -prefs=runtime.tools.esptool_py-2.6.1.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\esptool_py\2.6.1 -prefs=runtime.tools.mkspiffs.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\mkspiffs\0.2.3 -prefs=runtime.tools.mkspiffs-0.2.3.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\mkspiffs\0.2.3 -prefs=runtime.tools.xtensa-esp32-elf-gcc.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\xtensa-esp32-elf-gcc\1.22.0-80-g6c4433a-5.2.0 -prefs=runtime.tools.xtensa-esp32-elf-gcc-1.22.0-80-g6c4433a-5.2.0.path=C:\Users\Medad\Documents\ArduinoData\packages\esp32\tools\xtensa-esp32-elf-gcc\1.22.0-80-g6c4433a-5.2.0 -verbose C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\examples\Example2_VariousUnits\Example2_VariousUnits.ino

Using board 'featheresp32' from platform in folder: C:\Users\Medad\Documents\ArduinoData\packages\esp32\hardware\esp32\1.0.4

Using core 'esp32' from platform in folder: C:\Users\Medad\Documents\ArduinoData\packages\esp32\hardware\esp32\1.0.4

Detecting libraries used...

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -w -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -c -w -x c++ -E -CC -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\sketch\\Example2_VariousUnits.ino.cpp" -o nul -DARDUINO_LIB_DISCOVERY_PHASE

Alternatives for Wire.h: [Wire@1.0.1]

ResolveLibrary(Wire.h)

  -> candidates: [Wire@1.0.1]

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -w -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -c -w -x c++ -E -CC -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\sketch\\Example2_VariousUnits.ino.cpp" -o nul -DARDUINO_LIB_DISCOVERY_PHASE

Alternatives for SparkFun_PHT_MS8607_Arduino_Library.h: [SparkFun_PHT_MS8607_Arduino_Library@1.0.2]

ResolveLibrary(SparkFun_PHT_MS8607_Arduino_Library.h)

  -> candidates: [SparkFun_PHT_MS8607_Arduino_Library@1.0.2]

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -w -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -c -w -x c++ -E -CC -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\sketch\\Example2_VariousUnits.ino.cpp" -o nul -DARDUINO_LIB_DISCOVERY_PHASE

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -w -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -c -w -x c++ -E -CC -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src\\Wire.cpp" -o nul -DARDUINO_LIB_DISCOVERY_PHASE

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -w -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -c -w -x c++ -E -CC -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src\\SparkFun_PHT_MS8607_Arduino_Library.cpp" -o nul -DARDUINO_LIB_DISCOVERY_PHASE

Generating function prototypes...

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -w -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -c -w -x c++ -E -CC -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\sketch\\Example2_VariousUnits.ino.cpp" -o "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\preproc\\ctags_target_for_gcc_minus_e.cpp" -DARDUINO_LIB_DISCOVERY_PHASE

"C:\\Program Files\\WindowsApps\\ArduinoLLC.ArduinoIDE_1.8.42.0_x86__mdqgnx93n4wtt\\tools-builder\\ctags\\5.8-arduino11/ctags" -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\preproc\\ctags_target_for_gcc_minus_e.cpp"

Compiling sketch...

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Werror=all -Wextra -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -MMD -c -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\sketch\\Example2_VariousUnits.ino.cpp" -o "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\sketch\\Example2_VariousUnits.ino.cpp.o"

Compiling libraries...

Compiling library "Wire"

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Werror=all -Wextra -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -MMD -c -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src\\Wire.cpp" -o "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\libraries\\Wire\\Wire.cpp.o"

Compiling library "SparkFun_PHT_MS8607_Arduino_Library"

"C:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\tools\\xtensa-esp32-elf-gcc\\1.22.0-80-g6c4433a-5.2.0/bin/xtensa-esp32-elf-g++" -DESP_PLATFORM "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"" -DHAVE_CONFIG_H -DGCC_NOT_5_2_0=0 -DWITH_POSIX "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/config" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_trace" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/app_update" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/asio" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bootloader_support" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/bt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/coap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/console" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/driver" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-tls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_adc_cal" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_event" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_client" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_http_server" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_https_ota" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp_ringbuf" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ethernet" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/expat" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fatfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freemodbus" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/freertos" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/heap" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/idf_test" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/jsmn" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/json" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/libsodium" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/log" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/lwip" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mbedtls" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mdns" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/micro-ecc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/mqtt" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/newlib" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nghttp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/nvs_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/openssl" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protobuf-c" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/protocomm" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/pthread" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/sdmmc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/smartconfig_ack" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/soc" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spi_flash" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/spiffs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcp_transport" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/tcpip_adapter" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/ulp" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/vfs" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wear_levelling" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wifi_provisioning" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/wpa_supplicant" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/xtensa-debug-module" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp32-camera" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/esp-face" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4/tools/sdk/include/fb_gfx" -std=gnu++11 -Os -g3 -Wpointer-arith -fexceptions -fstack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wall -Werror=all -Wextra -Wno-error=maybe-uninitialized -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-missing-field-initializers -Wno-sign-compare -fno-rtti -MMD -c -DF_CPU=240000000L -DARDUINO=10813 -DARDUINO_FEATHER_ESP32 -DARDUINO_ARCH_ESP32 "-DARDUINO_BOARD=\"FEATHER_ESP32\"" "-DARDUINO_VARIANT=\"feather_esp32\"" -DESP32 -DCORE_DEBUG_LEVEL=0 "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\cores\\esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\variants\\feather_esp32" "-IC:\\Users\\Medad\\Documents\\ArduinoData\\packages\\esp32\\hardware\\esp32\\1.0.4\\libraries\\Wire\\src" "-IC:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src" "C:\\Users\\Medad\\Documents\\Arduino\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\src\\SparkFun_PHT_MS8607_Arduino_Library.cpp" -o "C:\\Users\\Medad\\AppData\\Local\\Temp\\arduino_build_974273\\libraries\\SparkFun_PHT_MS8607_Arduino_Library\\SparkFun_PHT_MS8607_Arduino_Library.cpp.o"

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp: In member function 'MS8607_status MS8607::hsensor_write_user_register(uint8_t)':

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp:357:11: warning: variable 'data' set but not used [-Wunused-but-set-variable]

   uint8_t data[2];

           ^

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp: In member function 'MS8607_status MS8607::hsensor_reset()':

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp:259:3: error: 'status' is used uninitialized in this function [-Werror=uninitialized]

   if (status != MS8607_status_ok)

   ^

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp: In member function 'MS8607_status MS8607::hsensor_read_user_register(uint8_t*)':

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp:328:3: error: 'status' is used uninitialized in this function [-Werror=uninitialized]

   if (status != MS8607_status_ok)

   ^

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp: In member function 'MS8607_status MS8607::psensor_read_eeprom_coeff(uint8_t, uint16_t*)':

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp:706:3: error: 'status' is used uninitialized in this function [-Werror=uninitialized]

   if (status != MS8607_status_ok)

   ^

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp: In member function 'MS8607_status MS8607::psensor_conversion_and_read_adc(uint8_t, uint32_t*)':

C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library\src\SparkFun_PHT_MS8607_Arduino_Library.cpp:792:3: error: 'status' is used uninitialized in this function [-Werror=uninitialized]

   if (status != MS8607_status_ok)

   ^

cc1plus.exe: some warnings being treated as errors

Using library Wire at version 1.0.1 in folder: C:\Users\Medad\Documents\ArduinoData\packages\esp32\hardware\esp32\1.0.4\libraries\Wire 

Using library SparkFun_PHT_MS8607_Arduino_Library at version 1.0.2 in folder: C:\Users\Medad\Documents\Arduino\libraries\SparkFun_PHT_MS8607_Arduino_Library 

exit status 1

Error compiling for board Adafruit ESP32 Feather.
```
</details>